### PR TITLE
Add support for BTLE connections on macOS 

### DIFF
--- a/bleuart.cpp
+++ b/bleuart.cpp
@@ -55,7 +55,17 @@ void BleUart::startConnect(QString addr)
     mUartServiceFound = false;
     mConnectDone = false;
 
+#if defined(Q_OS_MACOS) || defined(Q_OS_IOS)
+    // Create BT Controller from unique device UUID stored as addr. Creating
+    // a controller using a devices address is not supported on macOS or iOS.
+    QBluetoothDeviceInfo deviceInfo = QBluetoothDeviceInfo();
+    deviceInfo.setDeviceUuid(QBluetoothUuid(addr));
+    mControl = new QLowEnergyController(deviceInfo);
+
+#else
     mControl = new QLowEnergyController(QBluetoothAddress(addr));
+
+#endif
 
     mControl->setRemoteAddressType(QLowEnergyController::RandomAddress);
 
@@ -122,7 +132,14 @@ void BleUart::addDevice(const QBluetoothDeviceInfo &dev)
     if (dev.coreConfigurations() & QBluetoothDeviceInfo::LowEnergyCoreConfiguration) {
         qDebug() << "BLE scan found device:" << dev.name();
 
+#if defined(Q_OS_MACOS) || defined(Q_OS_IOS)
+        // macOS and iOS do not expose the hardware address of BLTE devices, must use
+        // the OS generated UUID.
+        mDevs.insert(dev.deviceUuid().toString(), dev.name());
+#else
         mDevs.insert(dev.address().toString(), dev.name());
+
+#endif
 
         emit scanDone(mDevs, false);
     }


### PR DESCRIPTION
Pull request to add good support to BTLE connection to the FOCBOX UI tool. Hopefully, I'm doing this right.